### PR TITLE
Fix transparent glass dock in production build

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -172,8 +172,10 @@ a:hover {
 		color-mix(in srgb, var(--bg-base) 55%, transparent),
 		color-mix(in srgb, var(--bg-base) 72%, transparent)
 	);
+	/* Only the standard property here — the build's Lightning CSS adds the -webkit- prefix
+	   from browser targets. Writing both by hand made it dedupe to ONLY the prefixed one,
+	   dropping the standard property, so the blur vanished on non-Safari desktop. */
 	backdrop-filter: blur(16px) saturate(180%);
-	-webkit-backdrop-filter: blur(16px) saturate(180%);
 	box-shadow:
 		/* soft lift + ambient shadow below */
 		0 8px 24px -6px rgb(0 0 0 / 0.28),


### PR DESCRIPTION
## Problem

On the **deployed** build (desktop), the liquid-glass scroll dock rendered **transparent** — you could see straight through it with only a faint border. Locally (dev) it was properly frosted/glassy.

## Cause

The `.liquid-glass` rule hand-wrote **both** the standard and prefixed property:

```css
backdrop-filter: blur(16px) saturate(180%);
-webkit-backdrop-filter: blur(16px) saturate(180%);
```

The production build's **Lightning CSS** minifier (via `@tailwindcss/vite`) treated them as redundant duplicates and deduplicated down to **only `-webkit-backdrop-filter`**, dropping the standard property. Non-Safari desktop browsers (Chrome, Edge, Firefox) need the *unprefixed* `backdrop-filter`, so they applied **no blur** → transparent dock. It looked fine locally only because dev CSS isn't minified (both survived).

## Fix

Keep only the standard `backdrop-filter` in source and let Lightning CSS add the `-webkit-` prefix from browser targets. Verified the built CSS now emits **both**:

```css
.liquid-glass{ -webkit-backdrop-filter:blur(16px)saturate(180%); backdrop-filter:blur(16px)saturate(180%); ... }
```

## Verification
- Ran `vite build` and inspected the emitted CSS — both prefixed and standard `backdrop-filter` present
- `npm run lint`: clean